### PR TITLE
Implement solution

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,7 @@ group :development, :test do
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
   gem 'rb-readline'
   gem 'rspec-rails'
+  gem 'pry-byebug'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,6 +106,7 @@ GEM
       msgpack (~> 1.2)
     builder (3.2.4)
     byebug (11.1.3)
+    coderay (1.1.3)
     concurrent-ruby (1.1.10)
     crass (1.0.6)
     diff-lcs (1.5.0)
@@ -184,6 +185,12 @@ GEM
     parser (3.1.2.0)
       ast (~> 2.4.1)
     pg (1.4.1)
+    pry (0.13.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-byebug (3.9.0)
+      byebug (~> 11.0)
+      pry (~> 0.13.0)
     public_suffix (4.0.7)
     puma (5.6.4)
       nio4r (~> 2.0)
@@ -336,6 +343,7 @@ DEPENDENCIES
   letter_opener_web
   listen (~> 3.3)
   pg
+  pry-byebug
   puma (~> 5.0)
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1.4, >= 6.1.4.1)

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -23,6 +23,14 @@ class EventsController < ApplicationController
     render :index
   end
 
+  def woman_only
+    @q = Event.woman_only.future.ransack(params[:q])
+    @events = @q.result(distinct: true).includes(:bookmarks, :prefecture, user: { avatar_attachment: :blob })
+                .order(held_at: :asc).page(params[:page])
+    @search_path = woman_only_events_path
+    render :index
+  end
+
   def new
     @event = Event.new
   end
@@ -60,6 +68,6 @@ class EventsController < ApplicationController
   private
 
   def event_params
-    params.require(:event).permit(:title, :content, :held_at, :prefecture_id, :thumbnail)
+    params.require(:event).permit(:title, :content, :held_at, :prefecture_id, :thumbnail, :gender)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -17,6 +17,6 @@ class UsersController < ApplicationController
   end
 
   def user_params
-    params.require(:user).permit(:email, :name, :password, :password_confirmation)
+    params.require(:user).permit(:email, :name, :gender, :password, :password_confirmation)
   end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -19,6 +19,7 @@ class Event < ApplicationRecord
     validates :title
     validates :content
     validates :held_at
+    validates :gender
   end
   
   enum gender: { anyone: 0, woman_only: 1}

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -13,12 +13,15 @@ class Event < ApplicationRecord
 
   scope :future, -> { where('held_at > ?', Time.current) }
   scope :past, -> { where('held_at <= ?', Time.current) }
+  scope :woman_only, -> { where((gender == 'woman_only'))}
 
   with_options presence: true do
     validates :title
     validates :content
     validates :held_at
   end
+  
+  enum gender: { anyone: 0, woman_only: 1}
 
   def past?
     held_at < Time.current

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,6 +19,7 @@ class User < ApplicationRecord
   validates :password_confirmation, presence: true, if: -> { new_record? || changes[:crypted_password] }
 
   validates :email, uniqueness: true
+  validates :gender, presence: true
 
   scope :allowing_created_event_notification,
         -> { joins(:notification_timings).merge(NotificationTiming.created_event) }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,7 +2,7 @@
 
 class User < ApplicationRecord
   authenticates_with_sorcery!
-
+  
   has_many :events, dependent: :destroy
   has_many :event_attendances, dependent: :destroy
   has_many :comments, dependent: :destroy
@@ -28,6 +28,8 @@ class User < ApplicationRecord
         -> { joins(:notification_timings).merge(NotificationTiming.attended_to_event) }
   scope :allowing_liked_event_notification,
         -> { joins(:notification_timings).merge(NotificationTiming.liked_event) }
+  
+  enum gender: { man: 0, woman: 1}
 
   def owner?(event)
     event.user_id == id

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -17,6 +17,13 @@
     <%= f.collection_select :prefecture_id, Prefecture.all, :id, :name, {}, class: 'form-select' %>
   </div>
   <div class="mb-3">
+    <%= f.label :gender %><br />
+    <%= f.label :anyone  %>
+    <%= f.radio_button :gender, :anyone %>
+    <%= f.label :woman_only  %>
+    <%= f.radio_button :gender, :woman_only %>
+  </div>
+  <div class="mb-3">
     <%= f.label :thumbnail %>
     <%= f.file_field :thumbnail, class: 'form-control js-file-select-preview mb-3', accept: 'image/*', data: { target: '#preview-target' } %>
     <%= image_tag f.object.decorate.thumbnail, id: 'preview-target', class: 'w-100 border' %>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -9,6 +9,9 @@
     <li class="nav-item" role="presentation">
       <a class="nav-link <%= active_if('events#past') %>" href="/events/past" role="tab">過去イベント</a>
     </li>
+    <li class="nav-item" role="presentation">
+      <a class="nav-link <%= active_if('events#woman_only') %>" href="/events/woman_only" role="tab">女性限定イベント</a>
+    </li>
   </ul>
 
   <div class="row row-cols-1 row-cols-md-3 g-4 mb-3">

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -85,20 +85,42 @@
           <div class="text-center">
             <% if logged_in? %>
               <% if !current_user.owner?(@event) %>
-                <% if current_user.attend?(@event) %>
-                  <%= link_to 'キャンセルする',
+                <% if @event.woman_only? %>
+                  <% if current_user.gender == 'woman' && current_user.attend?(@event) %>
+                    <%= link_to 'キャンセルする',
+                                event_attendance_url(@event),
+                                class: 'btn btn-primary',
+                                method: :delete,
+                                data: { confirm: 'キャンセルします' }
+                    %>
+                  <% elsif current_user.gender == 'woman' %>
+                    <%= link_to 'このもくもく会に参加する',
+                                event_attendance_url(@event),
+                                class: 'btn btn-primary',
+                                method: :post,
+                                data: { confirm: '申し込みます' }
+                    %>
+                  <% else %>
+                    <div class="p-3 bg">
+                      このイベントは女性限定です
+                    <div>
+                  <% end %>
+                <% else %>
+                  <% if current_user.attend?(@event) %>
+                    <%= link_to 'キャンセルする',
                               event_attendance_url(@event),
                               class: 'btn btn-primary',
                               method: :delete,
                               data: { confirm: 'キャンセルします' }
-                  %>
-                <% else %>
-                  <%= link_to 'このもくもく会に参加する',
+                    %>
+                  <% else %>
+                    <%= link_to 'このもくもく会に参加する',
                               event_attendance_url(@event),
                               class: 'btn btn-primary',
                               method: :post,
                               data: { confirm: '申し込みます' }
-                  %>
+                    %> 
+                  <% end %>
                 <% end %>
               <% end %>
             <% end %>

--- a/app/views/mypage/profiles/show.html.erb
+++ b/app/views/mypage/profiles/show.html.erb
@@ -38,6 +38,13 @@
           <%= f.label :name, class: 'form-label' %>
           <%= f.text_field :name, class: 'form-control', placeholder: 'らんてくん' %>
         </div>
+        <div class="mb-3">
+          <%= f.label :gender %><br />
+          <%= f.label :man  %>
+          <%= f.radio_button :gender, :man %>
+          <%= f.label :woman  %>
+          <%= f.radio_button :gender, :woman %>
+        </div>
         <div class="col-12">
           <!-- Button -->
           <%= f.submit class: 'btn btn-primary' %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -20,6 +20,13 @@
               <%= f.text_field :name, class: 'form-control' %>
             </div>
             <div class="mb-3">
+              <%= f.label :gender %><br />
+              <%= f.label :man  %>
+              <%= f.radio_button :gender, :man %>
+              <%= f.label :woman  %>
+              <%= f.radio_button :gender, :woman %>
+            </div>
+            <div class="mb-3">
               <%= f.label :email %>
               <%= f.email_field :email, class: 'form-control' %>
             </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
     collection do
       get :future
       get :past
+      get :woman_only
     end
     resource :attendance, only: %i[create destroy], module: :events
     resource :bookmark, only: %i[create destroy], module: :events

--- a/db/migrate/20220713162151_add_gender_to_users.rb
+++ b/db/migrate/20220713162151_add_gender_to_users.rb
@@ -1,0 +1,5 @@
+class AddGenderToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :gender, :integer
+  end
+end

--- a/db/migrate/20220714085736_add_gender_to_events.rb
+++ b/db/migrate/20220714085736_add_gender_to_events.rb
@@ -1,0 +1,5 @@
+class AddGenderToEvents < ActiveRecord::Migration[6.1]
+  def change
+    add_column :events, :gender, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_19_072358) do
+ActiveRecord::Schema.define(version: 2022_07_14_085736) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -78,6 +78,7 @@ ActiveRecord::Schema.define(version: 2022_01_19_072358) do
     t.integer "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "gender"
     t.index ["prefecture_id"], name: "index_events_on_prefecture_id"
     t.index ["user_id"], name: "index_events_on_user_id"
   end
@@ -135,6 +136,7 @@ ActiveRecord::Schema.define(version: 2022_01_19_072358) do
     t.string "name", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "gender"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 


### PR DESCRIPTION
## 概要

* 女性利用者を増やすための機能を追加 [(詳細README)](https://github.com/runteq/mokumoku/pull/1/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5)
## 変更内容

* サインアップ時に利用者の性別を入力できる機能の追加(プロフィール欄に反映)
<img src="https://i.gyazo.com/d6fda55b2609820b405c1efd5a150b98.png" width="350" height="400">
<img src="https://i.gyazo.com/69616597818af3f921484b443d8386fa.png" width="600" height="450">

* 女性限定イベントを開催できる機能の追加
<img src="https://i.gyazo.com/400c466d7077b9bca8ef8553c5a64b4f.png" width="400" height="400">

* もくもく会の一覧画面に,『女性限定イベント』一覧を追加
<img src="https://i.gyazo.com/d347122c4ad11333abde76ec5111a155.png" width="800" height="500">

* 女性限定のもくもく会の場合,男性ユーザーには『このもくもく会に参加する』ボタンを表示させず,『このもくもく会は女性限定です』と表示させる
<img src="https://i.gyazo.com/0b2e9e3d6244ac5da913905a8d04aeb9.png" width="450" height="400">
